### PR TITLE
Specification of file system encoding

### DIFF
--- a/textblob_fr/_text.py
+++ b/textblob_fr/_text.py
@@ -334,7 +334,7 @@ def _read(path, encoding="utf-8", comment=";;;"):
     if path:
         if type(path) in string_types and os.path.exists(path):
             # From file path.
-            f = open(path)
+            f = open(path, encoding="utf-8")
         elif type(path) in string_types:
             # From string.
             f = path.splitlines()

--- a/textblob_fr/_text.py
+++ b/textblob_fr/_text.py
@@ -10,6 +10,7 @@ from itertools import chain
 import types
 import os
 import re
+import codecs
 from xml.etree import cElementTree
 
 from .compat import text_type, string_types, basestring, imap, unicode
@@ -334,7 +335,7 @@ def _read(path, encoding="utf-8", comment=";;;"):
     if path:
         if type(path) in string_types and os.path.exists(path):
             # From file path.
-            f = open(path, encoding="utf-8")
+            f = codecs.open(path, "r", encoding="utf-8")
         elif type(path) in string_types:
             # From string.
             f = path.splitlines()


### PR DESCRIPTION
The desired file system encoding has to specified when using open. This correction save fatal errors when running python3 with another file system encoding than "utf-8" (like "ascii" for example which was my case on a Linux OpenSUSE distrib).