### PR TITLE
Python 3.7+ compatibility

### DIFF
--- a/textblob_fr/_text.py
+++ b/textblob_fr/_text.py
@@ -348,7 +348,7 @@ def _read(path, encoding="utf-8", comment=";;;"):
             if comment and line.startswith(comment):
                 continue
             yield line
-    raise StopIteration
+    return
 
 class Lexicon(lazydict):
 


### PR DESCRIPTION
Avoids the "RuntimeError: generator raised StopIteration" error with python 3.7+